### PR TITLE
Use .pk instead of .id

### DIFF
--- a/django_cleanup/models.py
+++ b/django_cleanup/models.py
@@ -19,11 +19,11 @@ def find_models_with_filefield():
     return result
 
 def remove_old_files(sender, instance, **kwargs):
-    if not instance.id:
+    if not instance.pk:
         return
 
     try:
-        old_instance = instance.__class__.objects.get(id=instance.id)
+        old_instance = instance.__class__.objects.get(pk=instance.pk)
     except instance.DoesNotExist:
         return
 


### PR DESCRIPTION
remove_old_files currently assumes that the primary key field of a model is named id, which will fail if the user has defined a custom primary key using primary_key=True.

Switching .id to .pk instead should be able to account for these edge cases.
