### PR TITLE
Send delete signals

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -3,18 +3,18 @@
 django-cleanup automatically deletes old file for FileField, ImageField and subclasses,
 and it also deletes files on models instance deletion.
 
-**Warning! If you use transactions you may lose you files if transaction will rollback. 
+**Warning! If you use transactions you may lose you files if transaction will rollback.
 If you are concerned about it you need other solution for old file deletion in your project.**
 
 Most django projects I've seen don't use transactions and this app is designed for such projects.
 
 ## How does it work?
 
-django-cleanup connects pre_save and post_delete signals to special functions(these functions 
+django-cleanup connects pre_save and post_delete signals to special functions(these functions
 delete old files) for each model which app is listed in INSTALLED_APPS above than 'django_cleanup'.
 
 ## Installation
-    
+
     pip install django-cleanup
 
 
@@ -28,6 +28,14 @@ Add django_cleanup to settings.py
     )
 
 **django_cleanup** should be placed after all your apps. (At least after those apps which need to remove files.)
+
+
+## Signals
+
+django-cleanup sends the following signals which can be imported from `django_cleanup.signals`:
+
+ * `cleanup_pre_delete` just _before_ a file is deleted. Passes a `file` keyword argument.
+ * `cleanup_post_delete` just _after_ a file is deleted. Passes a `file` keyword argument.
 
 
 ## License

--- a/django_cleanup/models.py
+++ b/django_cleanup/models.py
@@ -7,7 +7,7 @@ from django.db.models.signals import pre_save, post_delete
 logger = logging.getLogger(__name__)
 
 
-def find_models_with_filefield(): 
+def find_models_with_filefield():
     result = []
     for model in models.get_models():
         for field in model._meta.fields:
@@ -30,24 +30,24 @@ def remove_old_files(sender, instance, **kwargs):
             continue
         old_file = getattr(old_instance, field.name)
         new_file = getattr(instance, field.name)
-        storage = old_file.storage
-        if old_file and old_file != new_file and storage and storage.exists(old_file.name):
-            try:
-                storage.delete(old_file.name)
-            except Exception:
-                logger.exception("Unexpected exception while attempting to delete old file '%s'" % old_file.name)
+        if old_file != new_file:
+            delete_file(old_file)
 
 def remove_files(sender, instance, **kwargs):
     for field in instance._meta.fields:
         if not isinstance(field, models.FileField):
             continue
         file_to_delete = getattr(instance, field.name)
-        storage = file_to_delete.storage
-        if file_to_delete and storage and storage.exists(file_to_delete.name):
-            try:
-                storage.delete(file_to_delete.name)
-            except Exception:
-                logger.exception("Unexpected exception while attempting to delete file '%s'" % file_to_delete.name)
+        delete_file(file_to_delete)
+
+def delete_file(file_):
+    storage = file_.storage
+
+    if storage and storage.exists(file_.name):
+        try:
+            storage.delete(file_.name)
+        except Exception:
+            logger.exception("Unexpected exception while attempting to delete file '%s'" % file_.name)
 
 def connect_signals():
     for model in find_models_with_filefield():

--- a/django_cleanup/models.py
+++ b/django_cleanup/models.py
@@ -4,6 +4,9 @@ import django
 from django.db import models
 from django.db.models.signals import pre_save, post_delete
 
+from .signals import cleanup_pre_delete, cleanup_post_delete
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -45,7 +48,9 @@ def delete_file(file_):
 
     if storage and storage.exists(file_.name):
         try:
+            cleanup_pre_delete.send(sender=None, file=file_)
             storage.delete(file_.name)
+            cleanup_post_delete.send(sender=None, file=file_)
         except Exception:
             logger.exception("Unexpected exception while attempting to delete file '%s'" % file_.name)
 

--- a/django_cleanup/signals.py
+++ b/django_cleanup/signals.py
@@ -1,0 +1,4 @@
+from django.dispatch import Signal
+
+cleanup_pre_delete = Signal(providing_args=["file"])
+cleanup_post_delete = Signal(providing_args=["file"])


### PR DESCRIPTION
This adds a `cleanup_pre_delete` and `cleanup_post_delete` signal that will allow people to hook into django-cleanup's deletion of files. The specific motivation for this is so that there's a way to notify sorl-thumbnail to remove its thumbnail cache entry when a file is deleted. This pull request supersedes https://github.com/un1t/django-cleanup/pull/11 by solving the problem in a more elegant way.