### PR TITLE
Replace pre_save with post_save and cache original values in post_init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 *.egg-info
 .tox
 .coverage
-
+.cache

--- a/README.rst
+++ b/README.rst
@@ -1,23 +1,31 @@
-django-cleanup automatically deletes old file for FileField, ImageField and subclasses,
-and it also deletes files on models instance deletion.
+django-cleanup automatically deletes files for FileField, ImageField, and
+subclasses. It will delete old files when a new file is being save and it
+will delete files on model instance deletion.
 
-**Warning! If you use transactions you may lose you files if transaction will rollback.
-If you are concerned about it you need other solution for old file deletion in your project.**
+**Warning! If you use transactions you may lose files if a transaction will
+rollback at the right instance. Though this outcome is reduced by our use of
+post_save and post_delete signals, this outcome will still occur if there are
+errors in signals that are handled after our signals are handled. In this case
+the old file will be lost and the new file will not be referenced in a model,
+though the new file will likely still exist on disk. If you are concerned about
+it you need another solution for old file deletion in your project.
 
-Most django projects I've seen don't use transactions and this app is designed for such projects.
+This is fixed in Django 1.9+ if you are using a database that supports
+transactions.**
 
 Features
 ========
 
-- Support for Django 1.6, 1.7, 1.8
+- Support for Django 1.6, 1.7, 1.8, 1.9
 - Python 3 support
 - Compatible with sorl-thumbnail and easy-thumbnail
 
 How does it work?
 =================
 
-django-cleanup connects pre_save and post_delete signals to special functions(these functions
-delete old files) for each model which app is listed in INSTALLED_APPS above than 'django_cleanup'.
+django-cleanup connects post_init, post_save, and post_delete signals to special
+functions (these functions delete old files) for each model which app is listed
+in INSTALLED_APPS.
 
 Installation
 ============
@@ -32,10 +40,15 @@ Add django_cleanup to settings.py ::
 
     INSTALLED_APPS = (
         ...
-        'django_cleanup', # should go after your apps
+        # should go after your apps in django 1.6.
+        # in django 1.7+ this is fixed.
+        'django_cleanup',
     )
 
-**django_cleanup** should be placed after all your apps. (At least after those apps which need to remove files.)
+**django_cleanup** should be placed after all of your apps in django 1.6. (At
+least after those apps which need to remove files.) If you are using django 1.7+
+this is fixed with the new AppConfigs.
+
 
 
 Signals

--- a/django_cleanup/__init__.py
+++ b/django_cleanup/__init__.py
@@ -1,2 +1,2 @@
+__version__ = '0.3.1'
 default_app_config = 'django_cleanup.apps.CleanupConfig'
-

--- a/django_cleanup/models.py
+++ b/django_cleanup/models.py
@@ -1,64 +1,115 @@
+# coding: utf-8
+from collections import defaultdict
+
 import django
 from django.db import models
 try:
     from django.apps import apps
     get_models = apps.get_models
 except (ImportError, AttributeError):
+    # remove after dropping django 1.6
     get_models = models.get_models
-from django.db.models.signals import pre_save, post_delete
+try:
+    from django.db.transaction import on_commit
+except ImportError:
+    # remove after django 1.8 is deprecated(which will be awhile since it's LTS)
+    def on_commit(func, using=None):
+        func()
+from django.db.models.signals import post_init, post_save, post_delete
 
 from .signals import cleanup_pre_delete, cleanup_post_delete
 
-
-def find_models_with_filefield():
-    result = []
-    for model in get_models():
-        for field in model._meta.fields:
-            if isinstance(field, models.FileField):
-                result.append(model)
-                break
-    return result
+FIELDS_DEFAULT = lambda: []
+FIELDS = defaultdict(FIELDS_DEFAULT)
+CACHE_NAME = '_django_cleanup_original_cache'
 
 
-def remove_old_files(sender, instance, **kwargs):
-    if not instance.pk:
+def get_model_name(model):
+    '''returns a unique model name'''
+    return '{opt.app_label}.{opt.model_name}'.format(opt=model._meta)
+
+
+def fields_for_model_instance(instance):
+    '''Yields (name, descriptor) for each file field given an instance'''
+    model_name = get_model_name(instance)
+    if model_name in FIELDS:
+        for field_name in FIELDS[model_name]:
+            yield field_name, getattr(instance, field_name, None)
+
+
+def ensure_get_fields(opts):
+    ''' this can be removed when django 1.7 support is dropped'''
+    if hasattr(opts, 'get_fields'):
+        return opts
+    def get_fields():
+        return opts.fields
+    opts.get_fields = get_fields
+    return opts
+
+
+def cache_original_post_init(sender, instance, **kwargs):
+    '''Post_init on all models with file fields, saves original values'''
+    setattr(instance, CACHE_NAME, dict(fields_for_model_instance(instance)))
+
+
+def delete_old_post_save(sender, instance, raw, created, update_fields, using,
+                         **kwargs):
+    '''Post_save on all models with file fields, deletes old files'''
+    if raw or created:
         return
 
-    try:
-        old_instance = instance.__class__.objects.get(pk=instance.pk)
-    except instance.DoesNotExist:
-        return
-
-    for field in instance._meta.fields:
-        if not isinstance(field, models.FileField):
-            continue
-        old_file = getattr(old_instance, field.name)
-        new_file = getattr(instance, field.name)
-        if old_file != new_file:
-            delete_file(old_file)
+    for field_name, new_file in fields_for_model_instance(instance):
+        if update_fields is None or field_name in update_fields:
+            old_file = getattr(instance, CACHE_NAME)[field_name]
+            if old_file != new_file:
+                delete_file(old_file, using)
 
 
-def remove_files(sender, instance, **kwargs):
-    for field in instance._meta.fields:
-        if not isinstance(field, models.FileField):
-            continue
-        file_to_delete = getattr(instance, field.name)
-        delete_file(file_to_delete)
+def delete_all_post_delete(sender, instance, using, **kwargs):
+    '''Post_delete on all models with file fields, deletes all files'''
+    for field_name, file_ in fields_for_model_instance(instance):
+        delete_file(file_, using)
 
 
-def delete_file(file_):
+def delete_file(file_, using):
+    '''Deletes a file'''
     if not file_.name:
         return
-    cleanup_pre_delete.send(sender=None, file=file_)
-    file_.delete(save=False)
-    cleanup_post_delete.send(sender=None, file=file_)
+
+    # this will run after a successful commit for django 1.9+
+    # assuming you are in a transaction and on a database that supports
+    # transactions, otherwise it will run immediately
+    def run_on_commit():
+        cleanup_pre_delete.send(sender=None, file=file_)
+        file_.delete(save=False)
+        cleanup_post_delete.send(sender=None, file=file_)
+
+    on_commit(run_on_commit, using)
 
 
 def connect_signals():
-    for model in find_models_with_filefield():
-        pre_save.connect(remove_old_files, sender=model)
-        post_delete.connect(remove_files, sender=model)
+    if len(FIELDS) > 0:
+            return
 
+    def find_models_with_filefield():
+        for model in get_models():
+            opts = ensure_get_fields(model._meta)
+            name = get_model_name(model)
+            for field in opts.get_fields():
+                if isinstance(field, models.FileField):
+                    FIELDS[name].append(field.name)
+
+            if name in FIELDS:
+                yield model
+
+    for model in find_models_with_filefield():
+        key = '{{}}_django_cleanup_{}'.format(get_model_name(model))
+        post_init.connect(cache_original_post_init, sender=model,
+                          dispatch_uid=key.format('post_init'))
+        post_save.connect(delete_old_post_save, sender=model,
+                          dispatch_uid=key.format('post_save'))
+        post_delete.connect(delete_all_post_delete, sender=model,
+                            dispatch_uid=key.format('post_delete'))
 
 if django.VERSION < (1, 7):
     connect_signals()

--- a/django_cleanup/testapp/models.py
+++ b/django_cleanup/testapp/models.py
@@ -1,14 +1,36 @@
 # coding: utf-8
+from __future__ import unicode_literals
+
 from django.db import models
 from sorl.thumbnail import ImageField
 from easy_thumbnails.fields import ThumbnailerImageField
 from django_cleanup.signals import cleanup_pre_delete, cleanup_post_delete
 
 
-class Product(models.Model):
-    image = models.FileField(upload_to='testapp', blank=True)
+class ProductAbstract(models.Model):
+    image = models.FileField(upload_to='testapp', blank=True, null=True)
     sorl_image = ImageField(upload_to='testapp', blank=True)
     easy_image = ThumbnailerImageField(upload_to='testapp', blank=True)
+
+    class Meta:
+        abstract = True
+
+
+class Product(ProductAbstract):
+    pass
+
+
+class ProductProxy(Product):
+    class Meta:
+        proxy = True
+
+
+class ProductUnmanaged(ProductAbstract):
+    id = models.AutoField(primary_key=True)
+
+    class Meta:
+        managed = False
+        db_table = 'testapp_product'
 
 
 def sorl_delete(**kwargs):

--- a/django_cleanup/testapp/test_all.py
+++ b/django_cleanup/testapp/test_all.py
@@ -4,8 +4,20 @@ import shutil
 import pytest
 from flexmock import flexmock
 from django.conf import settings
+from django.db import router
+from django.db import transaction
 from django_cleanup.signals import cleanup_pre_delete, cleanup_post_delete
-from .models import Product
+from .models import Product, ProductProxy, ProductUnmanaged
+
+
+def get_using(instance):
+    return router.db_for_write(instance.__class__, instance=instance)
+
+
+def _raise(message):
+    def _func(x):
+        raise Exception(message)
+    return _func
 
 
 @pytest.yield_fixture
@@ -21,41 +33,117 @@ def pic1():
         os.remove(dst)
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 def test_replace_file(pic1):
     product = Product.objects.create(image=pic1['filename'])
     assert os.path.exists(pic1['path'])
     product.image = 'new.jpg'
-    product.save()
+    with transaction.atomic(get_using(product)):
+        product.save()
     assert not os.path.exists(pic1['path'])
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
+def test_replace_file_proxy(pic1):
+    product = ProductProxy.objects.create(image=pic1['filename'])
+    assert os.path.exists(pic1['path'])
+    product.image = 'new.jpg'
+    with transaction.atomic(get_using(product)):
+        product.save()
+    assert not os.path.exists(pic1['path'])
+
+
+@pytest.mark.django_db(transaction=True)
+def test_replace_file_unmanaged(pic1):
+    product = ProductUnmanaged.objects.create(image=pic1['filename'])
+    assert os.path.exists(pic1['path'])
+    product.image = 'new.jpg'
+    with transaction.atomic(get_using(product)):
+        product.save()
+    assert not os.path.exists(pic1['path'])
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.xfail(reason='https://code.djangoproject.com/ticket/18100')
+def test_replace_file_deferred(pic1):
+    '''probably shouldn't save from a deferred model but someone might do it'''
+    product = Product.objects.create(image=pic1['filename'])
+    assert os.path.exists(pic1['path'])
+    product_deferred = Product.objects.defer('sorl_image').get(id=product.id)
+    product_deferred.image = 'new.jpg'
+    with transaction.atomic(get_using(product)):
+        product_deferred.save()
+    assert not os.path.exists(pic1['path'])
+
+
+@pytest.mark.django_db(transaction=True)
 def test_remove_model_instance(pic1):
     product = Product.objects.create(image=pic1['filename'])
     assert os.path.exists(pic1['path'])
-    product.delete()
+    with transaction.atomic(get_using(product)):
+        product.delete()
     assert not os.path.exists(pic1['path'])
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
+def test_remove_model_instance_proxy(pic1):
+    product = ProductProxy.objects.create(image=pic1['filename'])
+    assert os.path.exists(pic1['path'])
+    with transaction.atomic(get_using(product)):
+        product.delete()
+    assert not os.path.exists(pic1['path'])
+
+
+@pytest.mark.django_db(transaction=True)
+def test_remove_model_instance_unmanaged(pic1):
+    product = ProductUnmanaged.objects.create(image=pic1['filename'])
+    assert os.path.exists(pic1['path'])
+    with transaction.atomic(get_using(product)):
+        product.delete()
+    assert not os.path.exists(pic1['path'])
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.xfail(reason='https://code.djangoproject.com/ticket/18100')
+def test_remove_model_instance_deferred(pic1):
+    product = Product.objects.create(image=pic1['filename'])
+    assert os.path.exists(pic1['path'])
+    product_deferred = Product.objects.defer('sorl_image').get(id=product.id)
+    with transaction.atomic(get_using(product)):
+        product_deferred.delete()
+    assert not os.path.exists(pic1['path'])
+
+
+@pytest.mark.django_db(transaction=True)
 def test_remove_blank_file(monkeypatch):
-    def _raise(message):
-        raise Exception(message)
-
     product = Product.objects.create(image='')
-    monkeypatch.setattr(product.image.storage, 'exists', lambda x: _raise('should not call exists'))
-    monkeypatch.setattr(product.image.storage, 'delete', lambda x: _raise('should not call delete'))
-    product.delete()
+    monkeypatch.setattr(
+        product.image.storage, 'exists', _raise('should not call exists'))
+    monkeypatch.setattr(
+        product.image.storage, 'delete', _raise('should not call delete'))
+    with transaction.atomic(get_using(product)):
+        product.delete()
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 def test_remove_not_exists():
     product = Product.objects.create(image='no-such-file')
-    product.delete()
+    with transaction.atomic(get_using(product)):
+        product.delete()
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
+def test_remove_none(monkeypatch):
+    product = Product.objects.create(image=None)
+    monkeypatch.setattr(
+        product.image.storage, 'exists', _raise('should not call exists'))
+    monkeypatch.setattr(
+        product.image.storage, 'delete', _raise('should not call delete'))
+    with transaction.atomic(get_using(product)):
+        product.delete()
+
+
+@pytest.mark.django_db(transaction=True)
 def test_sorlthumbnail_replace(pic1):
     # https://github.com/mariocesar/sorl-thumbnail
     from sorl.thumbnail import get_thumbnail
@@ -66,12 +154,13 @@ def test_sorlthumbnail_replace(pic1):
     thumbnail_path = os.path.join(settings.MEDIA_ROOT, im.name)
     assert os.path.exists(thumbnail_path)
     product.sorl_image = 'new.png'
-    product.save()
+    with transaction.atomic(get_using(product)):
+        product.save()
     assert not os.path.exists(pic1['path'])
     assert not os.path.exists(thumbnail_path)
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 def test_sorlthumbnail_delete(pic1):
     # https://github.com/mariocesar/sorl-thumbnail
     from sorl.thumbnail import get_thumbnail
@@ -81,12 +170,13 @@ def test_sorlthumbnail_delete(pic1):
         product.sorl_image, '100x100', crop='center', quality=50)
     thumbnail_path = os.path.join(settings.MEDIA_ROOT, im.name)
     assert os.path.exists(thumbnail_path)
-    product.delete()
+    with transaction.atomic(get_using(product)):
+        product.delete()
     assert not os.path.exists(pic1['path'])
     assert not os.path.exists(thumbnail_path)
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 def test_easythumbnails_replace(pic1):
     # https://github.com/SmileyChris/easy-thumbnails
     from easy_thumbnails.files import get_thumbnailer
@@ -97,12 +187,13 @@ def test_easythumbnails_replace(pic1):
     thumbnail_path = os.path.join(settings.MEDIA_ROOT, im.name)
     assert os.path.exists(thumbnail_path)
     product.easy_image = 'new.png'
-    product.save()
+    with transaction.atomic(get_using(product)):
+        product.save()
     assert not os.path.exists(pic1['path'])
     assert not os.path.exists(thumbnail_path)
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 def test_easythumbnails_delete(pic1):
     # https://github.com/SmileyChris/easy-thumbnails
     from easy_thumbnails.files import get_thumbnailer
@@ -112,6 +203,7 @@ def test_easythumbnails_delete(pic1):
         {'size': (100, 100)})
     thumbnail_path = os.path.join(settings.MEDIA_ROOT, im.name)
     assert os.path.exists(thumbnail_path)
-    product.delete()
+    with transaction.atomic(get_using(product)):
+        product.delete()
     assert not os.path.exists(pic1['path'])
     assert not os.path.exists(thumbnail_path)

--- a/setup.py
+++ b/setup.py
@@ -7,17 +7,33 @@
 #
 
 import os
+import re
+from codecs import open as codecs_open
 from setuptools import setup, find_packages
+
+
+def read(*parts):
+    file_path = os.path.join(os.path.dirname(__file__), *parts)
+    return codecs_open(file_path, encoding='utf-8').read()
+
+
+def find_version(*parts):
+    version_file = read(*parts)
+    version_match = re.search(
+        r'''^__version__ = ['"]([^'"]*)['"]''', version_file, re.M)
+    if version_match:
+        return str(version_match.group(1))
+    raise RuntimeError('Unable to find version string.')
 
 
 setup(
     name     = 'django-cleanup',
-    version  = '0.3.1',
+    version  = find_version('django_cleanup', '__init__.py'),
     packages = ['django_cleanup'],
     include_package_data=True,
-    requires = ['python (>= 2.5)', 'django (>= 1.6)'],
+    requires = ['python (>= 2.7)', 'django (>= 1.6)'],
     description  = 'Deletes old files.',
-    long_description = open('README.rst').read(),
+    long_description = read('README.rst'),
     author       = 'Ilya Shalyapin',
     author_email = 'ishalyapin@gmail.com',
     url          = 'https://github.com/un1t/django-cleanup',
@@ -33,5 +49,6 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,10 @@
 [tox]
 envlist =
-    {py27,py34}-django{16,17,18}
+    {py27,py34}-django{16,17,18,19}
+    py35-django19
 [testenv]
 deps =
+    django19: django<1.10
     django18: django<1.9
     django17: django<1.8
     django16: django<1.7


### PR DESCRIPTION
Django 1.9 support with transaction.on_commit.
Use `_meta` public api in django 1.8+.
Cache models names with filefields and the name of those fields at startup.
Add `dispatch_uid` to all signals.
Ensure `connect_signals` is idempotent.
Add tests for different model situations.
Deferred models don't work due to bug in django
    (https://code.djangoproject.com/ticket/18100).
PEP 0396 style `__version__` in module `__init__`.
Revise README.