### PR TITLE
Ignore models

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,6 +79,23 @@ Refresh the cleanup cache on the instance.
     ...
 
 
+Ignore cleanup for a specific model
+===================================
+Ignore a model and do not perform cleanup when the model is deleted or its files change.
+::
+
+    from django_cleanup import cleanup
+
+    ...
+
+    @cleanup.ignore()
+    class MyModel(models.Model):
+        image = models.FileField()
+
+    ...
+
+
+
 How to run tests
 ================
 ::

--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,6 @@ Refresh the cleanup cache on the instance.
     cleanup.refresh(instance)
     ...
 
-
 Ignore cleanup for a specific model
 ===================================
 Ignore a model and do not perform cleanup when the model is deleted or its files change.
@@ -93,8 +92,6 @@ Ignore a model and do not perform cleanup when the model is deleted or its files
         image = models.FileField()
 
     ...
-
-
 
 How to run tests
 ================

--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ Ignore a model and do not perform cleanup when the model is deleted or its files
 
     ...
 
-    @cleanup.ignore()
+    @cleanup.ignore
     class MyModel(models.Model):
         image = models.FileField()
 

--- a/django_cleanup/__init__.py
+++ b/django_cleanup/__init__.py
@@ -6,5 +6,5 @@
 '''
 from __future__ import unicode_literals
 
-__version__ = '3.1.0'
+__version__ = '3.2.dev0'
 default_app_config = 'django_cleanup.apps.CleanupConfig'

--- a/django_cleanup/cache.py
+++ b/django_cleanup/cache.py
@@ -33,16 +33,16 @@ else:
 
 def prepare():
     '''Prepare the cache for all models, non-reentrant'''
-    if len(FIELDS) > 0:  # pragma: no cover
+    if FIELDS:  # pragma: no cover
         return
 
     for model in apps.get_models():
-        opts = model._meta
-        name = get_model_name(model)
         if ignore_model(model):
             continue
+        name = get_model_name(model)
         if model_has_filefields(name):  # pragma: no cover
             continue
+        opts = model._meta
         for field in opts.get_fields():
             if isinstance(field, models.FileField):
                 add_field_for_model(name, field.name, field)
@@ -120,8 +120,8 @@ def get_model_name(model):
 
 
 def get_mangled_ignore(model):
-    '''returns a unique model name'''
-    return '_{opt.model_name}__cleanup_ignore'.format(opt=model._meta)
+    '''returns a mangled attribute name specific to the model'''
+    return '_{opt.model_name}__{opt.app_label}_cleanup_ignore'.format(opt=model._meta)
 
 
 # booleans ##

--- a/django_cleanup/cache.py
+++ b/django_cleanup/cache.py
@@ -39,8 +39,10 @@ def prepare():
     for model in apps.get_models():
         opts = model._meta
         name = get_model_name(model)
+        if ignore_model(model):
+            continue
         if model_has_filefields(name):  # pragma: no cover
-            return
+            continue
         for field in opts.get_fields():
             if isinstance(field, models.FileField):
                 add_field_for_model(name, field.name, field)
@@ -117,12 +119,22 @@ def get_model_name(model):
     return '{opt.app_label}.{opt.model_name}'.format(opt=model._meta)
 
 
+def get_mangled_ignore(model):
+    '''returns a unique model name'''
+    return '_{opt.model_name}__cleanup_ignore'.format(opt=model._meta)
+
+
 # booleans ##
 
 
 def model_has_filefields(model_name):
     '''Check if a model has filefields'''
     return model_name in FIELDS
+
+
+def ignore_model(model):
+    '''Check if a model should be ignored'''
+    return hasattr(model, get_mangled_ignore(model))
 
 
 # instance functions ##

--- a/django_cleanup/cleanup.py
+++ b/django_cleanup/cleanup.py
@@ -1,8 +1,8 @@
 '''Public utilities'''
 from __future__ import unicode_literals
 
-from .cache import make_cleanup_cache as _make_cleanup_cache
-from .cache import get_mangled_ignore as _get_mangled_ignore
+from .cache import (
+    get_mangled_ignore as _get_mangled_ignore, make_cleanup_cache as _make_cleanup_cache)
 
 
 __all__ = ['refresh', 'cleanup_ignore']
@@ -14,6 +14,7 @@ def refresh(instance):
 
 
 def ignore(cls):
+    '''Mark a model to ignore for cleanup'''
     setattr(cls, _get_mangled_ignore(cls), None)
     return cls
 cleanup_ignore = ignore

--- a/django_cleanup/cleanup.py
+++ b/django_cleanup/cleanup.py
@@ -2,11 +2,18 @@
 from __future__ import unicode_literals
 
 from .cache import make_cleanup_cache as _make_cleanup_cache
+from .cache import get_mangled_ignore as _get_mangled_ignore
 
 
-__all__ = ['refresh']
+__all__ = ['refresh', 'cleanup_ignore']
 
 
 def refresh(instance):
     '''Refresh the cache for an instance'''
     return _make_cleanup_cache(instance)
+
+
+def ignore(cls):
+    setattr(cls, _get_mangled_ignore(cls), None)
+    return cls
+cleanup_ignore = ignore

--- a/django_cleanup/handlers.py
+++ b/django_cleanup/handlers.py
@@ -109,7 +109,7 @@ def delete_file(instance, field_name, file_, using):
 
 
 def connect():
-
+    '''Connect signals to the cleanup models'''
     for model in cache.cleanup_models():
         key = '{{}}_django_cleanup_{}'.format(cache.get_model_name(model))
         post_init.connect(cache_original_post_init, sender=model,

--- a/django_cleanup/testapp/models.py
+++ b/django_cleanup/testapp/models.py
@@ -9,11 +9,20 @@ from django.db import models
 from easy_thumbnails.fields import ThumbnailerImageField
 from sorl.thumbnail import ImageField
 
+from django_cleanup import cleanup
+from django_cleanup.cleanup import cleanup_ignore
+
 
 def default_image():
     return os.path.join(settings.MEDIA_ROOT, 'pic.jpg')
 
 
+# ignore this cleanup_ignore decorator
+# it is only here to test that name mangling is in place
+# so that ignores on parent classes don't impact subclasses
+# and is not a demonstration on how to use this decorator
+# see the ProductIgnore model below for how to use the decorator
+@cleanup_ignore
 class ProductAbstract(models.Model):
     image = models.FileField(upload_to='testapp', blank=True, null=True)
     image_default = models.FileField(
@@ -29,6 +38,11 @@ class ProductAbstract(models.Model):
 
 
 class Product(ProductAbstract):
+    pass
+
+
+@cleanup.ignore
+class ProductIgnore(ProductAbstract):
     pass
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,4 +16,4 @@ deps =
     # Until at least April 2020
     django111: django<1.12
     -rdjango_cleanup/testapp/requirements.txt
-commands=pytest
+commands=pytest #django_cleanup/testapp/test_all.py::test_name


### PR DESCRIPTION
Ignore a model and do not perform cleanup when the model is deleted or its files change.

    from django_cleanup import cleanup

    ...

    @cleanup.ignore
    class MyModel(models.Model):
        image = models.FileField()