### PR TITLE
Removed providing_args kwarg from Signal construction.

### DIFF
--- a/django_cleanup/signals.py
+++ b/django_cleanup/signals.py
@@ -6,5 +6,5 @@ from django.dispatch import Signal
 
 __all__ = ['cleanup_pre_delete', 'cleanup_post_delete']
 
-cleanup_pre_delete = Signal(providing_args=["file"])
-cleanup_post_delete = Signal(providing_args=["file"])
+cleanup_pre_delete = Signal()
+cleanup_post_delete = Signal()


### PR DESCRIPTION
Django 3.1 deprecated the use of the `providing_args` keyword args to `Signal`, since they're being removed in 4.0. The argument was always just informational, so removing it has no behavioral effect.