### PR TITLE
Feature/5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,15 @@ matrix:
       env: TOXENV=py38-django30
     - python: "pypy3"
       env: TOXENV=pypy3-django30
+
+    - python: "3.6"
+      env: TOXENV=py36-django31
+    - python: "3.7"
+      env: TOXENV=py37-django31
+    - python: "3.8"
+      env: TOXENV=py38-django31
+    - python: "pypy3"
+      env: TOXENV=pypy3-django31
 install: pip install tox-travis
 script: tox # setting TOXENV is equivalent to calling `tox -e [ENV]`
 notifications:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,11 @@
+# Changelog
+
+
+## [5.1.0] - 2020-09
+### Added
+- This CHANGELOG
+
+### Removed
+- Removed providing_args kwarg from Signal construction. [@coredumperror](https://github.com/coredumperror)
+
+[5.1.0]: https://github.com/un1t/django-cleanup/compare/5.0.0...5.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [5.1.0] - 2020-09-15
 ### Added
-- This change log
+- This change log.
 
 ### Changed
 - Update to run tests for django 3.1. #76 [@johnthagen](https://github.com/johnthagen)
@@ -69,10 +69,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.3.0]: https://github.com/un1t/django-cleanup/compare/0.2.1...0.3.0
 [0.2.1]: https://github.com/un1t/django-cleanup/compare/0.2.0...0.2.1
 [0.2.0]: https://github.com/un1t/django-cleanup/compare/0.1.13...0.2.0
-[0.1.13]: https://github.com/u1t/django-cleanup/compare/0.1.12...0.1.13
-[0.1.12]: https://github.com/u1t/django-cleanup/compare/0.1.11...0.1.12
-[0.1.11]: https://github.com/u1t/django-cleanup/compare/0.1.10...0.1.11
-[0.1.10]: https://github.com/u1t/django-cleanup/compare/0.1.9...0.1.10
+[0.1.13]: https://github.com/un1t/django-cleanup/compare/0.1.12...0.1.13
+[0.1.12]: https://github.com/un1t/django-cleanup/compare/0.1.11...0.1.12
+[0.1.11]: https://github.com/un1t/django-cleanup/compare/0.1.10...0.1.11
+[0.1.10]: https://github.com/un1t/django-cleanup/compare/0.1.9...0.1.10
 [0.1.9]: https://github.com/un1t/django-cleanup/compare/0.1.8...0.1.9
 [0.1.8]: https://github.com/un1t/django-cleanup/compare/0.1.7...0.1.8
 [0.1.7]: https://github.com/un1t/django-cleanup/compare/0.1.6...0.1.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [5.1.0] - 2020-09-15
 ### Added
-- This change log.
+- This change log. Resolves issue [#73] for [@DmytroLitvinov](https://github.com/DmytroLitvinov).
 
 ### Changed
-- Update to run tests for django 3.1. #76 [@johnthagen](https://github.com/johnthagen)
-- Update to document support for django 3.1. #76 [@johnthagen](https://github.com/johnthagen)
+- Update to run tests for django 3.1. PR [#76] from [@johnthagen](https://github.com/johnthagen).
+- Update to document support for django 3.1. PR [#76] from [@johnthagen](https://github.com/johnthagen).
 
 ### Removed
-- Removed providing_args kwarg from Signal construction. #74 [@coredumperror](https://github.com/coredumperror)
+- Removed providing_args kwarg from Signal construction. PR [#74] from [@coredumperror](https://github.com/coredumperror).
 
 ## [5.0.0] - 2020-06-07
 ## [4.0.1] - 2020-06-06
@@ -80,3 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.1.5]: https://github.com/un1t/django-cleanup/compare/0.1.4...0.1.5
 [0.1.4]: https://github.com/un1t/django-cleanup/compare/0.1.0...0.1.4
 [0.1.0]: https://github.com/un1t/django-cleanup/releases/tag/0.1.0
+
+[#76]: https://github.com/un1t/django-cleanup/pull/76
+[#74]: https://github.com/un1t/django-cleanup/pull/74
+[#73]: https://github.com/un1t/django-cleanup/issues/73

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@
 ### Added
 - This change log
 
+### Changed
+- Update to run tests for django 3.1. #76 [@johnthagen](https://github.com/johnthagen)
+- Update to document support for django 3.1. #76 [@johnthagen](https://github.com/johnthagen)
+
 ### Removed
-- Removed providing_args kwarg from Signal construction. [@coredumperror](https://github.com/coredumperror)
+- Removed providing_args kwarg from Signal construction. #74 [@coredumperror](https://github.com/coredumperror)
 
 [5.1.0]: https://github.com/un1t/django-cleanup/compare/5.0.0...5.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
+All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.1.0] - 2020-09-xx
+## [Unreleased]
+
+## [5.1.0] - 2020-09-15
 ### Added
 - This change log
 
@@ -12,4 +17,66 @@
 ### Removed
 - Removed providing_args kwarg from Signal construction. #74 [@coredumperror](https://github.com/coredumperror)
 
+## [5.0.0] - 2020-06-07
+## [4.0.1] - 2020-06-06
+## [4.0.0] - 2019-07-13
+## [3.2.0] - 2019-02-17
+## [3.1.0] - 2019-02-05
+## [3.0.1] - 2018-11-18
+## [3.0.0] - 2018-11-18
+## [2.1.0] - 2017-12-30
+## [2.0.0] - 2017-12-27
+## [1.1.0] - 2017-12-27
+## [1.0.1] - 2017-07-14
+## [1.0.0] - 2017-06-30
+## [0.4.2] - 2015-12-17
+## [0.4.1] - 2015-12-02
+## [0.4.0] - 2015-10-06
+## [0.3.1] - 2015-06-25
+## [0.3.0] - 2015-05-12
+## [0.2.1] - 2015-03-07
+## [0.2.0] - 2015-03-06
+## [0.1.13] - 2015-02-21
+## [0.1.12] - 2015-02-08
+## [0.1.11] - 2015-02-01
+## [0.1.10] - 2014-04-29
+## [0.1.9] - 2014-04-29
+## [0.1.8] - 2013-04-07
+## [0.1.7] - 2013-04-03
+## [0.1.6] - 2013-02-12
+## [0.1.5] - 2012-08-17
+## [0.1.4] - 2012-08-16
+## [0.1.0] - 2012-08-14
+
+[Unreleased]: https://github.com/un1t/django-cleanup/compare/5.1.0...HEAD
 [5.1.0]: https://github.com/un1t/django-cleanup/compare/5.0.0...5.1.0
+[5.0.0]: https://github.com/un1t/django-cleanup/compare/4.0.1...5.0.0
+[4.0.1]: https://github.com/un1t/django-cleanup/compare/4.0.0...4.0.1
+[4.0.0]: https://github.com/un1t/django-cleanup/compare/3.2.0...4.0.0
+[3.2.0]: https://github.com/un1t/django-cleanup/compare/3.1.0...3.2.0
+[3.1.0]: https://github.com/un1t/django-cleanup/compare/3.0.1...3.1.0
+[3.0.1]: https://github.com/un1t/django-cleanup/compare/3.0.0...3.0.1
+[3.0.0]: https://github.com/un1t/django-cleanup/compare/2.1.0...3.0.0
+[2.1.0]: https://github.com/un1t/django-cleanup/compare/2.0.0...2.1.0
+[2.0.0]: https://github.com/un1t/django-cleanup/compare/1.1.0...2.0.0
+[1.1.0]: https://github.com/un1t/django-cleanup/compare/1.0.1...1.1.0
+[1.0.1]: https://github.com/un1t/django-cleanup/compare/1.0.0...1.0.1
+[1.0.0]: https://github.com/un1t/django-cleanup/compare/0.4.2...1.0.0
+[0.4.2]: https://github.com/un1t/django-cleanup/compare/0.4.1...0.4.2
+[0.4.1]: https://github.com/un1t/django-cleanup/compare/0.4.0...0.4.1
+[0.4.0]: https://github.com/un1t/django-cleanup/compare/0.3.1...0.4.0
+[0.3.1]: https://github.com/un1t/django-cleanup/compare/0.3.0...0.3.1
+[0.3.0]: https://github.com/un1t/django-cleanup/compare/0.2.1...0.3.0
+[0.2.1]: https://github.com/un1t/django-cleanup/compare/0.2.0...0.2.1
+[0.2.0]: https://github.com/un1t/django-cleanup/compare/0.1.13...0.2.0
+[0.1.13]: https://github.com/u1t/django-cleanup/compare/0.1.12...0.1.13
+[0.1.12]: https://github.com/u1t/django-cleanup/compare/0.1.11...0.1.12
+[0.1.11]: https://github.com/u1t/django-cleanup/compare/0.1.10...0.1.11
+[0.1.10]: https://github.com/u1t/django-cleanup/compare/0.1.9...0.1.10
+[0.1.9]: https://github.com/un1t/django-cleanup/compare/0.1.8...0.1.9
+[0.1.8]: https://github.com/un1t/django-cleanup/compare/0.1.7...0.1.8
+[0.1.7]: https://github.com/un1t/django-cleanup/compare/0.1.6...0.1.7
+[0.1.6]: https://github.com/un1t/django-cleanup/compare/0.1.5...0.1.6
+[0.1.5]: https://github.com/un1t/django-cleanup/compare/0.1.4...0.1.5
+[0.1.4]: https://github.com/un1t/django-cleanup/compare/0.1.0...0.1.4
+[0.1.0]: https://github.com/olivierlacan/keep-a-changelog/releases/tag/0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 
 
-## [5.1.0] - 2020-09
+## [5.1.0] - 2020-09-xx
 ### Added
-- This CHANGELOG
+- This change log
 
 ### Removed
 - Removed providing_args kwarg from Signal construction. [@coredumperror](https://github.com/coredumperror)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,4 +79,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.1.6]: https://github.com/un1t/django-cleanup/compare/0.1.5...0.1.6
 [0.1.5]: https://github.com/un1t/django-cleanup/compare/0.1.4...0.1.5
 [0.1.4]: https://github.com/un1t/django-cleanup/compare/0.1.0...0.1.4
-[0.1.0]: https://github.com/olivierlacan/keep-a-changelog/releases/tag/0.1.0
+[0.1.0]: https://github.com/un1t/django-cleanup/releases/tag/0.1.0

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.rst
 include LICENSE
+include CHANGELOG

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include README.rst
 include LICENSE
-include CHANGELOG
+include CHANGELOG.md

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ is set as the :code:`FileField`'s default value will not be deleted.
 
 Compatibility
 -------------
-- Django 2.2, 3.0 (`See Django Supported Versions <https://www.djangoproject.com/download/#supported-versions>`_)
+- Django 2.2, 3.0, 3.1 (`See Django Supported Versions <https://www.djangoproject.com/download/#supported-versions>`_)
 - Python 3.5+
 - Compatible with `sorl-thumbnail <https://github.com/jazzband/sorl-thumbnail>`_
 - Compatible with `easy-thumbnail <https://github.com/SmileyChris/easy-thumbnails>`_

--- a/django_cleanup/__init__.py
+++ b/django_cleanup/__init__.py
@@ -3,5 +3,5 @@
     subclasses. It will delete old files when a new file is being save and it
     will delete files on model instance deletion.
 '''
-__version__ = '5.1.0-dev'
+__version__ = '5.1.0'
 default_app_config = 'django_cleanup.apps.CleanupConfig'

--- a/django_cleanup/__init__.py
+++ b/django_cleanup/__init__.py
@@ -3,5 +3,5 @@
     subclasses. It will delete old files when a new file is being save and it
     will delete files on model instance deletion.
 '''
-__version__ = '5.0.0'
+__version__ = '5.1.0-dev'
 default_app_config = 'django_cleanup.apps.CleanupConfig'

--- a/django_cleanup/signals.py
+++ b/django_cleanup/signals.py
@@ -6,5 +6,5 @@ from django.dispatch import Signal
 
 __all__ = ['cleanup_pre_delete', 'cleanup_post_delete']
 
-cleanup_pre_delete = Signal(providing_args=["file"])
-cleanup_post_delete = Signal(providing_args=["file"])
+cleanup_pre_delete = Signal()
+cleanup_post_delete = Signal()

--- a/django_cleanup/signals.py
+++ b/django_cleanup/signals.py
@@ -6,5 +6,10 @@ from django.dispatch import Signal
 
 __all__ = ['cleanup_pre_delete', 'cleanup_post_delete']
 
+
 cleanup_pre_delete = Signal()
+'''Called just before a file is deleted. Passes a `file` keyword argument.'''
+
+
 cleanup_post_delete = Signal()
+'''Called just after a file is deleted. Passes a `file` keyword argument.'''

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         'Framework :: Django',
         'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.0',
+        'Framework :: Django :: 3.1',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{35,36,37,38,py3}-django22
-    py{36,37,38,py3}-django{30,master}
+    py{36,37,38,py3}-django{30,31,master}
 [testenv]
 deps =
     djangomaster: https://github.com/django/django/tarball/master


### PR DESCRIPTION
Release 5.1.

Remove deprecated `providing_args` from `Signal` construction.
Add django 3.1 support.
Add change log, resolves #73