### PR TITLE
Fix cache loosing sync if file exists on save

### DIFF
--- a/django_cleanup/handlers.py
+++ b/django_cleanup/handlers.py
@@ -38,14 +38,15 @@ def fallback_pre_save(sender, instance, raw, update_fields, using, **kwargs):
 def delete_old_post_save(sender, instance, raw, created, update_fields, using,
                          **kwargs):
     '''Post_save on all models with file fields, deletes old files'''
-    if raw or created:
+    if raw:
         return
 
-    for field_name, new_file in cache.fields_for_model_instance(instance):
-        if update_fields is None or field_name in update_fields:
-            old_file = cache.get_field_attr(instance, field_name)
-            if old_file != new_file:
-                delete_file(instance, field_name, old_file, using)
+    if not created:
+        for field_name, new_file in cache.fields_for_model_instance(instance):
+            if update_fields is None or field_name in update_fields:
+                old_file = cache.get_field_attr(instance, field_name)
+                if old_file != new_file:
+                    delete_file(instance, field_name, old_file, using)
 
     # reset cache
     cache.make_cleanup_cache(instance)


### PR DESCRIPTION
If a file is specified which already exists, the FileField generates a random suffix to choose a different location.
Currently, this is not synced to the cache which results in not deleting the correct file.

It seems to be an edge-case, because on creation as well as on edit the destination of the file needs to be occupied to hit this bug.