### PR TITLE
Fix default_app_config deprecation

### DIFF
--- a/django_cleanup/__init__.py
+++ b/django_cleanup/__init__.py
@@ -1,10 +1,10 @@
-import django
-
 '''
     django-cleanup automatically deletes files for FileField, ImageField, and
     subclasses. It will delete old files when a new file is being save and it
     will delete files on model instance deletion.
 '''
+import django
+
 __version__ = '6.0.0-dev'
 if django.VERSION < (3, 2):
     default_app_config = 'django_cleanup.apps.CleanupConfig'

--- a/django_cleanup/__init__.py
+++ b/django_cleanup/__init__.py
@@ -1,7 +1,11 @@
+import django
+
 '''
     django-cleanup automatically deletes files for FileField, ImageField, and
     subclasses. It will delete old files when a new file is being save and it
     will delete files on model instance deletion.
 '''
 __version__ = '5.2.0'
-default_app_config = 'django_cleanup.apps.CleanupConfig'
+
+if django.VERSION < (3, 2):
+    default_app_config = 'django_cleanup.apps.CleanupConfig'


### PR DESCRIPTION
Django 3.2 automatically detects AppConfig and therefore this setting is no longer required.

https://docs.djangoproject.com/en/dev/releases/3.2/#automatic-appconfig-discovery