### PR TITLE
Select models and fields via settings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -157,6 +157,21 @@ mark a model for cleanup:
     class MyModel(models.Model):
         image = models.FileField()
 
+Only cleanup selected fields
+----------------------------
+If you prefer to explicitly configure which fields django-cleanup will handle, you can use the :code:`CLEANUP` setting in your settings.py:
+
+.. code-block:: py
+
+    CLEANUP = {
+        'model.name': {'field1', 'field2'},  # Only clean these fields for this model
+        'other.model': {'field3'}  # Only clean field3 for other.model
+    }
+
+The setting maps model names (in the format "app_label.model_name") to sets of field names that should be cleaned up.
+
+Note that if :code:`CLEANUP` is set and a model or field is not included in the :code:`CLEANUP` setting, its files will not be cleaned up.
+
 How to run tests
 ================
 Install, setup and use pyenv_ to install all the required versions of cPython

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,5 +49,6 @@ pythonpath = [".", "src"]
 addopts = ["-v", "--cov-report=term-missing", "--cov=django_cleanup"]
 markers = [
     "cleanup_selected_config: marks test as using the CleanupSelectedConfig app config",
+    "cleanup_settings: marks test as using the CLEANUP django setting",
     "django_storage: change django storage backends"
 ]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -21,6 +21,9 @@ def pytest_collection_modifyitems(items):
 
 @pytest.fixture(autouse=True)
 def setup_django_cleanup_state(request, settings):
+    settings_marker = request.node.get_closest_marker("cleanup_settings")
+    settings.CLEANUP = settings_marker.args[0] if settings_marker else None
+
     for model in cache.cleanup_models():
         suffix = f'_django_cleanup_{cache.get_model_name(model)}'
         post_init.disconnect(None, sender=model,

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -432,3 +432,47 @@ def test__select_config__replace_file_with_file_ignore(picture):
     new_image_path = os.path.join(django_settings.MEDIA_ROOT, random_pic_name)
     assert product.image.path == new_image_path
 #endregion
+
+
+#region cleanup settings
+@pytest.mark.cleanup_settings({'test.product': {'image'}})
+def test_cleanup_settings_model_included(picture):
+    product = Product.objects.create(image=picture['filename'])
+    assert os.path.exists(picture['path'])
+    random_pic_name = get_random_pic_name()
+    product.image = random_pic_name
+    with transaction.atomic(get_using(product)):
+        product.save()
+    assert not os.path.exists(picture['path'])
+    assert product.image
+    new_image_path = os.path.join(django_settings.MEDIA_ROOT, random_pic_name)
+    assert product.image.path == new_image_path
+
+
+@pytest.mark.cleanup_settings({'test.other_model': {'image'}})
+def test_cleanup_settings_model_excluded(picture):
+    product = Product.objects.create(image=picture['filename'])
+    assert os.path.exists(picture['path'])
+    random_pic_name = get_random_pic_name()
+    product.image = random_pic_name
+    with transaction.atomic(get_using(product)):
+        product.save()
+    assert os.path.exists(picture['path'])  # File should not be cleaned up
+    assert product.image
+    new_image_path = os.path.join(django_settings.MEDIA_ROOT, random_pic_name)
+    assert product.image.path == new_image_path
+
+
+@pytest.mark.cleanup_settings({'test.product': {'other_field'}})
+def test_cleanup_settings_field_excluded(picture):
+    product = Product.objects.create(image=picture['filename'])
+    assert os.path.exists(picture['path'])
+    random_pic_name = get_random_pic_name()
+    product.image = random_pic_name
+    with transaction.atomic(get_using(product)):
+        product.save()
+    assert os.path.exists(picture['path'])  # File should not be cleaned up
+    assert product.image
+    new_image_path = os.path.join(django_settings.MEDIA_ROOT, random_pic_name)
+    assert product.image.path == new_image_path
+#endregion


### PR DESCRIPTION
Select models and fields via settings, allowing for more granular filtering of what is or isn't included in cleanup.

```py
CLEANUP = {
    # "core.achievement": {"frame", "image", "obscure_image"},
    "core.achievementupload": {"achievement_csv"},
    "core.bitstreamversion": {"asset_file"},
    "core.cerberusversion": {"asset_file"},
    "core.feedpost": {"image"},
    # "core.machine": {"backglass_art", "logo", "template_file"},
    "core.recording": {"file"},
    "core.scoredetectorversion": {"asset_file"},
    "core.scoreimage": {"image"},
    # "core.session": {"log_file"},
    "core.slideshowimage": {"image"},
    # "core.spike2firmwareversion": {"asset_file"},
    "core.userprofile": {"profile_picture"},
}
```

Note I didn't do anything different for `select_mode` given it got confusing fast, maybe it's easier to consider this as a layer on top of whatever app config has been selected, it's essentially select mode but more granular.

Mostly I've based the setting syntax off of what `FIELDS` stores anyway, given it's quite similar to how other packages like cacheops are configured.

Might be nice to `fnmatch` the model same as cacheops so you can do `"core.*"` but I didn't bother at this point.

This resolves https://github.com/un1t/django-cleanup/issues/113.